### PR TITLE
fix: don't overwrite a dependency that already exists in root Cargo.toml

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,10 +92,6 @@ pub fn auto_inherit() -> Result<(), anyhow::Error> {
     let mut was_modified = false;
     for (package_name, source) in &package_name2inherited_source {
         if workspace_deps.get(package_name).is_some() {
-            eprintln!(
-                "`{}` won't be auto-inherited because it's already present in the root manifest.",
-                package_name
-            );
             continue;
         } else {
             insert_preserving_decor(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,12 +91,20 @@ pub fn auto_inherit() -> Result<(), anyhow::Error> {
         .expect("Failed to find `[workspace.dependencies]` table in root manifest.");
     let mut was_modified = false;
     for (package_name, source) in &package_name2inherited_source {
-        insert_preserving_decor(
-            workspace_deps,
-            package_name,
-            dep2toml_item(&shared2dep(source)),
-        );
-        was_modified = true;
+        if workspace_deps.get(package_name).is_some() {
+            eprintln!(
+                "`{}` won't be auto-inherited because it's already present in the root manifest.",
+                package_name
+            );
+            continue;
+        } else {
+            insert_preserving_decor(
+                workspace_deps,
+                package_name,
+                dep2toml_item(&shared2dep(source)),
+            );
+            was_modified = true;
+        }
     }
     if was_modified {
         fs_err::write(


### PR DESCRIPTION
- Checks if a package already exists on root Cargo.toml before attempting to include the ones inherited from member Cargo.tomls

#### Before
![image](https://github.com/mainmatter/cargo-autoinherit/assets/15948633/be7da9ca-03ef-4e5d-ba84-140e19ccb0c3)

#### After
![image](https://github.com/mainmatter/cargo-autoinherit/assets/15948633/f18e5e6e-4527-4f7f-8fdd-79ac8790b5a0)


closes #10