### PR TITLE
Add flag to exclude specified workspace members

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use cargo_autoinherit::auto_inherit;
 
-use clap::Parser;
+use clap::{Args, Parser};
 
 #[derive(Parser)]
 #[command(bin_name = "cargo")]
@@ -13,10 +13,20 @@ struct CliWrapper {
 pub enum CargoInvocation {
     /// Automatically centralize all dependencies as workspace dependencies.
     #[command(name = "autoinherit")]
-    AutoInherit,
+    AutoInherit(AutoInheritArgs),
+}
+
+#[derive(Args)]
+pub struct AutoInheritArgs {
+    /// Package name(s) of workspace member(s) to exclude.
+    #[arg(short, long)]
+    exclude: Vec<String>,
 }
 
 fn main() -> Result<(), anyhow::Error> {
-    let _cli = CliWrapper::parse();
-    auto_inherit()
+    let cli = CliWrapper::parse();
+
+    match cli.command {
+        CargoInvocation::AutoInherit(args) => auto_inherit(args.exclude),
+    }
 }


### PR DESCRIPTION
There may be workspace members which have to stay in sync with other workspaces and should be excluded from the auto-inheritance. This commits allows to specify such workspace members by their package name.