### PR TITLE
Add flag for dry-run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,23 @@ pub struct AutoInheritArgs {
     /// Package name(s) of workspace member(s) to exclude.
     #[arg(short, long)]
     exclude: Vec<String>,
+
+    /// No changes but exit code 1 if anything would be changed or any dependencies cannot be inherited.
+    #[arg(short, long, action)]
+    dry_run: bool,
 }
 
 fn main() -> Result<(), anyhow::Error> {
     let cli = CliWrapper::parse();
 
     match cli.command {
-        CargoInvocation::AutoInherit(args) => auto_inherit(args.exclude),
+        CargoInvocation::AutoInherit(args) => {
+            let code = auto_inherit(args.exclude, args.dry_run)?;
+            if code != 0 {
+                std::process::exit(code);
+            } else {
+                Ok(())
+            }
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use cargo_autoinherit::auto_inherit;
 
-use clap::Parser;
+use clap::{Args, Parser};
 
 #[derive(Parser)]
 #[command(bin_name = "cargo")]
@@ -13,10 +13,20 @@ struct CliWrapper {
 pub enum CargoInvocation {
     /// Automatically centralize all dependencies as workspace dependencies.
     #[command(name = "autoinherit")]
-    AutoInherit,
+    AutoInherit(AutoInheritArgs),
+}
+
+#[derive(Args)]
+pub struct AutoInheritArgs {
+    /// Package name(s) of workspace member(s) to exclude.
+    #[arg(short, long)]
+    exclude: Vec<String>,
 }
 
 fn main() -> Result<(), anyhow::Error> {
-    let _cli = CliWrapper::parse();
-    auto_inherit()
+    let cli = CliWrapper::parse();
+
+    match cli.command {
+        CargoInvocation::AutoInherit(args) => auto_inherit(args.exclude),
+    }
 }


### PR DESCRIPTION
With the dry-run capability, cargo-autoinherit can be run in CI and used
to enforce strict inheritance except for excluded workspace members.
   
The dry run will not touch any files in the workspace. However if any
file would be touched or there are any dependencies which could not be
autoinherited, it returns with a non-zero exit code.