### PR TITLE
Add support for path dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "clap",
  "fs-err",
  "guppy",
+ "pathdiff",
  "semver",
  "toml",
  "toml_edit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cargo-manifest = "0.14.0"
 toml = "0.8.10"
 semver = "1.0.22"
 toml_edit = "0.22.6"
+pathdiff = "0.2.1"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ cargo autoinherit
 
 ## Limitations
 
-- `cargo-autoinherit` won't auto-inherit path dependencies.
 - `cargo-autoinherit` won't auto-inherit dependencies from private registries.
 - `cargo-autoinherit` will only merge version requirements that are obviously compatible (e.g. 
   `^1.0.0` and `^1.1.5` will be merged to `^1.1.5`, but `^1.0.0` and `>=1,<2` won't be merged).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,38 @@ pub struct AutoInheritConf {
     pub prefer_simple_dotted: bool,
 }
 
+/// Rewrites a `path` dependency as being absolute, based on a given path
+fn rewrite_dep_paths_as_absolute<'a, P: AsRef<std::path::Path>>(
+    deps: impl Iterator<Item = &'a mut Dependency>,
+    parent: P,
+) {
+    deps.for_each(|dep| {
+        if let Dependency::Detailed(detail) = dep {
+            detail.path = detail.path.as_mut().map(|path| {
+                parent
+                    .as_ref()
+                    .join(path)
+                    .canonicalize()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            })
+        }
+    });
+}
+
+/// Rewrites a `path` dependency as being relative, based on a given path
+fn rewrite_dep_path_as_relative<P: AsRef<std::path::Path>>(dep: &mut Dependency, parent: P) {
+    if let Dependency::Detailed(detail) = dep {
+        detail.path = detail.path.as_mut().map(|path| {
+            pathdiff::diff_paths(path, parent.as_ref())
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        })
+    }
+}
+
 pub fn auto_inherit(conf: &AutoInheritConf) -> Result<(), anyhow::Error> {
     let metadata = guppy::MetadataCommand::new().exec().context(
         "Failed to execute `cargo metadata`. Was the command invoked inside a Rust project?",
@@ -39,25 +71,38 @@ pub fn auto_inherit(conf: &AutoInheritConf) -> Result<(), anyhow::Error> {
     };
 
     let mut package_name2specs: BTreeMap<String, Action> = BTreeMap::new();
-    if let Some(deps) = &workspace.dependencies {
+    if let Some(deps) = &mut workspace.dependencies {
+        rewrite_dep_paths_as_absolute(deps.values_mut(), workspace_root);
         process_deps(deps, &mut package_name2specs);
     }
 
     for member_id in graph.workspace().member_ids() {
         let package = graph.metadata(member_id)?;
         assert!(package.in_workspace());
-        let manifest: Manifest = {
+        let mut manifest: Manifest = {
             let contents = fs_err::read_to_string(package.manifest_path().as_std_path())
                 .context("Failed to read root manifest")?;
             toml::from_str(&contents).context("Failed to parse root manifest")?
         };
-        if let Some(deps) = &manifest.dependencies {
+        if let Some(deps) = &mut manifest.dependencies {
+            rewrite_dep_paths_as_absolute(
+                deps.values_mut(),
+                package.manifest_path().parent().unwrap(),
+            );
             process_deps(deps, &mut package_name2specs);
         }
-        if let Some(deps) = &manifest.dev_dependencies {
+        if let Some(deps) = &mut manifest.dev_dependencies {
+            rewrite_dep_paths_as_absolute(
+                deps.values_mut(),
+                package.manifest_path().parent().unwrap(),
+            );
             process_deps(deps, &mut package_name2specs);
         }
-        if let Some(deps) = &manifest.build_dependencies {
+        if let Some(deps) = &mut manifest.build_dependencies {
+            rewrite_dep_paths_as_absolute(
+                deps.values_mut(),
+                package.manifest_path().parent().unwrap(),
+            );
             process_deps(deps, &mut package_name2specs);
         }
     }
@@ -103,11 +148,10 @@ pub fn auto_inherit(conf: &AutoInheritConf) -> Result<(), anyhow::Error> {
         if workspace_deps.get(package_name).is_some() {
             continue;
         } else {
-            insert_preserving_decor(
-                workspace_deps,
-                package_name,
-                dep2toml_item(&shared2dep(source)),
-            );
+            let mut dep = shared2dep(source);
+            rewrite_dep_path_as_relative(&mut dep, workspace_root);
+
+            insert_preserving_decor(workspace_deps, package_name, dep2toml_item(&dep));
             was_modified = true;
         }
     }
@@ -305,6 +349,9 @@ enum DependencySource {
         tag: Option<String>,
         rev: Option<String>,
     },
+    Path {
+        path: String,
+    },
 }
 
 impl std::fmt::Display for DependencySource {
@@ -327,6 +374,10 @@ impl std::fmt::Display for DependencySource {
                 if let Some(rev) = rev {
                     write!(f, ", rev: {}", rev)?;
                 }
+                Ok(())
+            }
+            DependencySource::Path { path } => {
+                write!(f, "path: {}", path)?;
                 Ok(())
             }
         }
@@ -356,11 +407,11 @@ fn dep2shared_dep(dep: &Dependency) -> SourceType {
             if d.registry.is_some() || d.registry_index.is_some() {
                 return SourceType::MustBeSkipped;
             }
-            // We ignore path deps for now.
             if d.path.is_some() {
-                return SourceType::MustBeSkipped;
-            }
-            if let Some(git) = &d.git {
+                source = Some(DependencySource::Path {
+                    path: d.path.as_ref().unwrap().to_owned(),
+                });
+            } else if let Some(git) = &d.git {
                 source = Some(DependencySource::Git {
                     git: git.to_owned(),
                     branch: d.branch.to_owned(),
@@ -415,6 +466,20 @@ fn shared2dep(shared_dependency: &SharedDependency) -> Dependency {
             branch: branch.clone(),
             tag: tag.clone(),
             rev: rev.clone(),
+            features: None,
+            optional: None,
+            default_features: if *default_features { None } else { Some(false) },
+        }),
+        DependencySource::Path { path } => Dependency::Detailed(DependencyDetail {
+            package: None,
+            version: None,
+            registry: None,
+            registry_index: None,
+            path: Some(path.clone()),
+            git: None,
+            branch: None,
+            tag: None,
+            rev: None,
             features: None,
             optional: None,
             default_features: if *default_features { None } else { Some(false) },


### PR DESCRIPTION
    feat: add multiple-location support
    
    Cargo supports specifying multiple locations for a dependency.
    Specifically, a git or path location can coexist with a version
    location. In these cases Cargo will use the version to refer to a
    registry when the crate is published, or otherwise use the version as a
    constraint against a local crate.
 
---
 
    feat: add support for path dependencies