### PR TITLE
feat: allow optional simple dotted style

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,12 @@ use toml_edit::{Array, Key};
 
 mod dedup;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, clap::Args)]
 pub struct AutoInheritConf {
-    /// Represents inherited dependencies as `package.workspace = true` if possible.
+    #[arg(
+        long,
+        help = "Represents inherited dependencies as `package.workspace = true` if possible."
+    )]
     pub prefer_simple_dotted: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use cargo_autoinherit::auto_inherit;
+use cargo_autoinherit::{auto_inherit, AutoInheritConf};
 
 use clap::Parser;
 
@@ -13,10 +13,21 @@ struct CliWrapper {
 pub enum CargoInvocation {
     /// Automatically centralize all dependencies as workspace dependencies.
     #[command(name = "autoinherit")]
-    AutoInherit,
+    AutoInherit {
+        /// Represents inherited dependencies as `package.workspace = true` if possible.
+        #[arg(long)]
+        prefer_simple_dotted: bool,
+    },
 }
 
 fn main() -> Result<(), anyhow::Error> {
-    let _cli = CliWrapper::parse();
-    auto_inherit()
+    let cli = CliWrapper::parse();
+    let conf = match cli.command {
+        CargoInvocation::AutoInherit {
+            prefer_simple_dotted,
+        } => AutoInheritConf {
+            prefer_simple_dotted,
+        },
+    };
+    auto_inherit(&conf)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,21 +13,11 @@ struct CliWrapper {
 pub enum CargoInvocation {
     /// Automatically centralize all dependencies as workspace dependencies.
     #[command(name = "autoinherit")]
-    AutoInherit {
-        /// Represents inherited dependencies as `package.workspace = true` if possible.
-        #[arg(long)]
-        prefer_simple_dotted: bool,
-    },
+    AutoInherit(AutoInheritConf),
 }
 
 fn main() -> Result<(), anyhow::Error> {
     let cli = CliWrapper::parse();
-    let conf = match cli.command {
-        CargoInvocation::AutoInherit {
-            prefer_simple_dotted,
-        } => AutoInheritConf {
-            prefer_simple_dotted,
-        },
-    };
+    let CargoInvocation::AutoInherit(conf) = cli.command;
     auto_inherit(&conf)
 }


### PR DESCRIPTION
This allows you to prefer that inherited workspace dependencies be expressed as `package.workspace = true` rather than using an inline table in cases where there are no other attributes on the dependency needed.