### PR TITLE
Fix handling of non-UTF8 sequences in path rewrites

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,11 @@ fn rewrite_dep_path_as_relative<P: AsRef<std::path::Path>>(dep: &mut Dependency,
     if let Dependency::Detailed(detail) = dep {
         detail.path = detail.path.as_mut().map(|path| {
             pathdiff::diff_paths(path, parent.as_ref())
-                .unwrap()
-                .to_string_lossy()
+                .expect(
+                    "Error rewriting dependency path as relative: unable to determine path diff.",
+                )
+                .to_str()
+                .expect("Error rewriting dependency path as relative: path diff is not UTF-8.")
                 .to_string()
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,8 @@ fn rewrite_dep_paths_as_absolute<'a, P: AsRef<std::path::Path>>(
                     .join(path)
                     .canonicalize()
                     .unwrap()
-                    .to_string_lossy()
+                    .to_str()
+                    .expect("Canonicalized absolute path contained non-UTF-8 segments.")
                     .to_string()
             })
         }
@@ -81,7 +82,7 @@ fn rewrite_dep_paths_as_absolute<'a, P: AsRef<std::path::Path>>(
 fn rewrite_dep_path_as_relative<P: AsRef<std::path::Path>>(dep: &mut Dependency, parent: P) {
     if let Dependency::Detailed(detail) = dep {
         detail.path = detail.path.as_mut().map(|path| {
-            pathdiff::diff_paths(path, parent.as_ref())
+            pathdiff::diff_paths(path, parent.as_ref().canonicalize().unwrap())
                 .expect(
                     "Error rewriting dependency path as relative: unable to determine path diff.",
                 )


### PR DESCRIPTION
Addresses comments ([1](https://github.com/mainmatter/cargo-autoinherit/pull/28#discussion_r1824028502) and [2](https://github.com/mainmatter/cargo-autoinherit/pull/28#discussion_r1824029820)) in #28 