### PR TITLE
Add snapshot test based on Gerust-generated project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +85,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,8 +123,11 @@ dependencies = [
  "cargo-manifest",
  "clap",
  "fs-err",
+ "git2",
  "guppy",
+ "insta",
  "pathdiff",
+ "rand",
  "semver",
  "toml",
  "toml_edit",
@@ -131,6 +165,17 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "cc"
+version = "1.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f57c4b4da2a9d619dd035f27316d7a426305b75be93d09e92f2b9229c34feaf"
+dependencies = [
+ "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -196,16 +241,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "debug-ignore"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "equivalent"
@@ -218,6 +292,15 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs-err"
@@ -237,6 +320,34 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -285,6 +396,145 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +542,20 @@ checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "insta"
+version = "1.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+dependencies = [
+ "console",
+ "globset",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+ "walkdir",
 ]
 
 [[package]]
@@ -310,10 +574,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -334,6 +671,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +711,21 @@ checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -371,10 +747,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -426,10 +858,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -452,6 +902,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -490,6 +951,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -534,10 +1005,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "url"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -546,10 +1046,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-sys"
@@ -627,11 +1146,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -640,6 +1196,49 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,12 @@ installers = []
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
+
+[dev-dependencies]
+git2 = "0.19.0"
+insta = { version = "1.41", features = ["glob"] }
+rand = "0.8.5"
+
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,0 +1,69 @@
+use std::{env::temp_dir, fs, path::PathBuf};
+
+use cargo_autoinherit::{auto_inherit, AutoInheritConf};
+use git2::Repository;
+use insta::assert_snapshot;
+use rand::{
+    distributions::{Alphanumeric, DistString},
+    thread_rng,
+};
+
+const TEST_REPO_URL: &str = match option_env!("TEST_REPO_URL") {
+    Some(url) => url,
+    None => "https://github.com/hdoordt/cargo-autoinherit-test",
+};
+
+fn clone_test_project() -> PathBuf {
+    let dir: String = Alphanumeric.sample_string(&mut thread_rng(), 32);
+    let dir = temp_dir().join(dir);
+    Repository::clone(TEST_REPO_URL, &dir).expect("Error cloning test repository");
+    dir
+}
+
+fn run_with_conf(conf: AutoInheritConf) -> PathBuf {
+    let repo_path = clone_test_project();
+
+    let conf = AutoInheritConf {
+        manifest_path: Some(PathBuf::from(format!(
+            "{}/Cargo.toml",
+            repo_path.to_str().unwrap()
+        ))),
+        ..conf
+    };
+    auto_inherit(conf).unwrap();
+    repo_path
+}
+
+#[test]
+fn default_behavior() {
+    let repo_path = run_with_conf(AutoInheritConf::default());
+    insta::glob!(repo_path, "**/Cargo.toml", |p| {
+        let input = fs::read_to_string(dbg!(p)).unwrap();
+        assert_snapshot!(input);
+    });
+}
+
+#[test]
+fn prefer_simple_dotted() {
+    let repo_path = run_with_conf(AutoInheritConf {
+        prefer_simple_dotted: true,
+        ..Default::default()
+    });
+    insta::glob!(repo_path, "**/Cargo.toml", |p| {
+        let input = fs::read_to_string(dbg!(p)).unwrap();
+        assert_snapshot!(input);
+    });
+}
+
+#[test]
+fn with_excluded_member() {
+    let repo_path = run_with_conf(AutoInheritConf {
+        prefer_simple_dotted: false,
+        exclude_members: vec!["cargo-autoinherit-test-cli".to_string()],
+        ..Default::default()
+    });
+    insta::glob!(repo_path, "**/Cargo.toml", |p| {
+        let input = fs::read_to_string(dbg!(p)).unwrap();
+        assert_snapshot!(input);
+    });
+}

--- a/tests/snapshots/main__default_behavior@Cargo.toml.snap
+++ b/tests/snapshots/main__default_behavior@Cargo.toml.snap
@@ -1,0 +1,48 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[workspace]
+members = [
+    "cli",
+    "config",
+    "db",
+    "web",
+    "macros"
+]
+resolver = "2"
+default-members = ["web"]
+
+[workspace.metadata.cargo-autoinherit]
+# Skip cargo-autoinherit for these packages
+exclude-members = [
+    "cargo-autoinherit-test-web"
+]
+
+[workspace.dependencies]
+anyhow = "1.0"
+cargo-autoinherit-test-config = { path = "config" }
+clap = "4.4"
+cruet = "0.14"
+dotenvy = "0.15"
+fake = "2.9"
+figment = "0.10"
+googletest = "0.12"
+guppy = "0.17"
+include_dir = "0.7"
+insta = "1.38"
+liquid = "~0.26"
+quote = "1.0"
+rand = "0.8"
+regex = "1.10"
+serde = "1.0"
+sqlx = "0.8"
+syn = "2.0"
+thiserror = "1.0"
+tokio = "1.34"
+tracing = "0.1"
+url = "2.5"
+utoipa = "5.1.3"
+uuid = "1.5"
+validator = "0.18"

--- a/tests/snapshots/main__default_behavior@cli__Cargo.toml.snap
+++ b/tests/snapshots/main__default_behavior@cli__Cargo.toml.snap
@@ -1,0 +1,36 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-cli"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without additional setup
+doctest = false
+
+[[bin]]
+name = "db"
+path = "src/bin/db.rs"
+[[bin]]
+name = "generate"
+path = "src/bin/generate.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+cruet = { workspace = true }
+guppy = { workspace = true }
+include_dir = { workspace = true }
+liquid = { workspace = true }
+cargo-autoinherit-test-config = { workspace = true }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono"] }
+url = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/tests/snapshots/main__default_behavior@config__Cargo.toml.snap
+++ b/tests/snapshots/main__default_behavior@config__Cargo.toml.snap
@@ -1,0 +1,25 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-config"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without config files being in place, etc.
+doctest = false
+
+[dependencies]
+anyhow = { workspace = true }
+dotenvy = { workspace = true }
+figment = { workspace = true, features = ["toml", "env"] }
+serde = { workspace = true, features = ["derive"] } 
+tracing = { workspace = true }
+
+[dev-dependencies]
+figment = { workspace = true, features = ["toml", "env", "test"] }
+googletest = { workspace = true }

--- a/tests/snapshots/main__default_behavior@db__Cargo.toml.snap
+++ b/tests/snapshots/main__default_behavior@db__Cargo.toml.snap
@@ -1,0 +1,31 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-db"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without a running database, etc.
+doctest = false
+
+[features]
+test-helpers = ["dep:fake", "dep:rand", "dep:regex"]
+openapi = ["dep:utoipa"]
+
+[dependencies]
+anyhow = { workspace = true }
+fake = { workspace = true, features = ["derive"], optional = true }
+cargo-autoinherit-test-config = { workspace = true }
+rand = { workspace = true, optional = true }
+regex = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono"] }
+thiserror = { workspace = true }
+utoipa = { workspace = true, features = ["uuid"], optional = true }
+uuid = { workspace = true, features = ["serde"] }
+validator = { workspace = true, features = ["derive"] }

--- a/tests/snapshots/main__default_behavior@macros__Cargo.toml.snap
+++ b/tests/snapshots/main__default_behavior@macros__Cargo.toml.snap
@@ -1,0 +1,19 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-macros"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+proc-macro = true
+# examples in docs don't run without a running database, etc.
+doctest = false
+
+[dependencies]
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }

--- a/tests/snapshots/main__default_behavior@web__Cargo.toml.snap
+++ b/tests/snapshots/main__default_behavior@web__Cargo.toml.snap
@@ -1,0 +1,45 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-web"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without a running database, etc.
+doctest = false
+
+[features]
+test-helpers = ["dep:serde_json", "dep:tower", "dep:hyper"]
+
+[dependencies]
+anyhow = "1.0"
+axum = { version = "0.7", features = ["macros"] }
+cargo-autoinherit-test-config = { path = "../config" }
+cargo-autoinherit-test-db = { path = "../db", features = ["openapi"] }
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.34", features = ["full"] }
+tower-http = { version = "0.6", features = ["full"] }
+tracing = "0.1"
+tracing-panic = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry", "fmt"] }
+uuid = { version = "1.6", features = ["serde"] }
+serde_json = { version = "1.0", optional = true }
+thiserror = "1.0"
+tower = { version = "0.5", features = ["util"], optional = true }
+hyper = { version = "1.0", features = ["full"], optional = true }
+cargo-autoinherit-test-macros = { path = "../macros" }
+validator = { version = "0.18.1", features = ["derive"] }
+utoipa = { version = "5.1.2", features = ["axum_extras", "uuid"] }
+utoipa-axum = {version = "0.1.2" }
+utoipa-swagger-ui = { version = "8.0.3", features = ["axum", "reqwest"] }
+
+[dev-dependencies]
+fake = "2.9"
+googletest = "0.12"
+cargo-autoinherit-test-db = { path = "../db", features = ["test-helpers"] }
+cargo-autoinherit-test-web = { path = ".", features = ["test-helpers"] }

--- a/tests/snapshots/main__prefer_simple_dotted@Cargo.toml.snap
+++ b/tests/snapshots/main__prefer_simple_dotted@Cargo.toml.snap
@@ -1,0 +1,48 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[workspace]
+members = [
+    "cli",
+    "config",
+    "db",
+    "web",
+    "macros"
+]
+resolver = "2"
+default-members = ["web"]
+
+[workspace.metadata.cargo-autoinherit]
+# Skip cargo-autoinherit for these packages
+exclude-members = [
+    "cargo-autoinherit-test-web"
+]
+
+[workspace.dependencies]
+anyhow = "1.0"
+cargo-autoinherit-test-config = { path = "config" }
+clap = "4.4"
+cruet = "0.14"
+dotenvy = "0.15"
+fake = "2.9"
+figment = "0.10"
+googletest = "0.12"
+guppy = "0.17"
+include_dir = "0.7"
+insta = "1.38"
+liquid = "~0.26"
+quote = "1.0"
+rand = "0.8"
+regex = "1.10"
+serde = "1.0"
+sqlx = "0.8"
+syn = "2.0"
+thiserror = "1.0"
+tokio = "1.34"
+tracing = "0.1"
+url = "2.5"
+utoipa = "5.1.3"
+uuid = "1.5"
+validator = "0.18"

--- a/tests/snapshots/main__prefer_simple_dotted@cli__Cargo.toml.snap
+++ b/tests/snapshots/main__prefer_simple_dotted@cli__Cargo.toml.snap
@@ -1,0 +1,36 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-cli"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without additional setup
+doctest = false
+
+[[bin]]
+name = "db"
+path = "src/bin/db.rs"
+[[bin]]
+name = "generate"
+path = "src/bin/generate.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+cruet.workspace = true
+guppy.workspace = true
+include_dir.workspace = true
+liquid.workspace = true
+cargo-autoinherit-test-config.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono"] }
+url.workspace = true
+tokio = { workspace = true, features = ["full"] }
+
+[dev-dependencies]
+insta.workspace = true

--- a/tests/snapshots/main__prefer_simple_dotted@config__Cargo.toml.snap
+++ b/tests/snapshots/main__prefer_simple_dotted@config__Cargo.toml.snap
@@ -1,0 +1,25 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-config"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without config files being in place, etc.
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+dotenvy.workspace = true
+figment = { workspace = true, features = ["toml", "env"] }
+serde = { workspace = true, features = ["derive"] } 
+tracing.workspace = true
+
+[dev-dependencies]
+figment = { workspace = true, features = ["toml", "env", "test"] }
+googletest.workspace = true

--- a/tests/snapshots/main__prefer_simple_dotted@db__Cargo.toml.snap
+++ b/tests/snapshots/main__prefer_simple_dotted@db__Cargo.toml.snap
@@ -1,0 +1,31 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-db"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without a running database, etc.
+doctest = false
+
+[features]
+test-helpers = ["dep:fake", "dep:rand", "dep:regex"]
+openapi = ["dep:utoipa"]
+
+[dependencies]
+anyhow.workspace = true
+fake = { workspace = true, features = ["derive"], optional = true }
+cargo-autoinherit-test-config.workspace = true
+rand = { workspace = true, optional = true }
+regex = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono"] }
+thiserror.workspace = true
+utoipa = { workspace = true, features = ["uuid"], optional = true }
+uuid = { workspace = true, features = ["serde"] }
+validator = { workspace = true, features = ["derive"] }

--- a/tests/snapshots/main__prefer_simple_dotted@macros__Cargo.toml.snap
+++ b/tests/snapshots/main__prefer_simple_dotted@macros__Cargo.toml.snap
@@ -1,0 +1,19 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-macros"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+proc-macro = true
+# examples in docs don't run without a running database, etc.
+doctest = false
+
+[dependencies]
+quote.workspace = true
+syn = { workspace = true, features = ["full"] }

--- a/tests/snapshots/main__prefer_simple_dotted@web__Cargo.toml.snap
+++ b/tests/snapshots/main__prefer_simple_dotted@web__Cargo.toml.snap
@@ -1,0 +1,45 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-web"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without a running database, etc.
+doctest = false
+
+[features]
+test-helpers = ["dep:serde_json", "dep:tower", "dep:hyper"]
+
+[dependencies]
+anyhow = "1.0"
+axum = { version = "0.7", features = ["macros"] }
+cargo-autoinherit-test-config = { path = "../config" }
+cargo-autoinherit-test-db = { path = "../db", features = ["openapi"] }
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.34", features = ["full"] }
+tower-http = { version = "0.6", features = ["full"] }
+tracing = "0.1"
+tracing-panic = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry", "fmt"] }
+uuid = { version = "1.6", features = ["serde"] }
+serde_json = { version = "1.0", optional = true }
+thiserror = "1.0"
+tower = { version = "0.5", features = ["util"], optional = true }
+hyper = { version = "1.0", features = ["full"], optional = true }
+cargo-autoinherit-test-macros = { path = "../macros" }
+validator = { version = "0.18.1", features = ["derive"] }
+utoipa = { version = "5.1.2", features = ["axum_extras", "uuid"] }
+utoipa-axum = {version = "0.1.2" }
+utoipa-swagger-ui = { version = "8.0.3", features = ["axum", "reqwest"] }
+
+[dev-dependencies]
+fake = "2.9"
+googletest = "0.12"
+cargo-autoinherit-test-db = { path = "../db", features = ["test-helpers"] }
+cargo-autoinherit-test-web = { path = ".", features = ["test-helpers"] }

--- a/tests/snapshots/main__with_excluded_member@Cargo.toml.snap
+++ b/tests/snapshots/main__with_excluded_member@Cargo.toml.snap
@@ -1,0 +1,40 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[workspace]
+members = [
+    "cli",
+    "config",
+    "db",
+    "web",
+    "macros"
+]
+resolver = "2"
+default-members = ["web"]
+
+[workspace.metadata.cargo-autoinherit]
+# Skip cargo-autoinherit for these packages
+exclude-members = [
+    "cargo-autoinherit-test-web"
+]
+
+[workspace.dependencies]
+anyhow = "1.0"
+cargo-autoinherit-test-config = { path = "config" }
+dotenvy = "0.15"
+fake = "2.9"
+figment = "0.10"
+googletest = "0.12"
+quote = "1.0"
+rand = "0.8"
+regex = "1.10"
+serde = "1.0"
+sqlx = "0.8"
+syn = "2.0"
+thiserror = "1.0"
+tracing = "0.1"
+utoipa = "5.1.3"
+uuid = "1.5"
+validator = "0.18"

--- a/tests/snapshots/main__with_excluded_member@cli__Cargo.toml.snap
+++ b/tests/snapshots/main__with_excluded_member@cli__Cargo.toml.snap
@@ -1,0 +1,36 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-cli"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without additional setup
+doctest = false
+
+[[bin]]
+name = "db"
+path = "src/bin/db.rs"
+[[bin]]
+name = "generate"
+path = "src/bin/generate.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4.4", features = ["derive"] }
+cruet = "0.14"
+guppy = "0.17"
+include_dir = "0.7"
+liquid = "~0.26"
+cargo-autoinherit-test-config = { path = "../config" }
+sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono" ] }
+url = "2.5"
+tokio = { version = "1.34", features = ["full"] }
+
+[dev-dependencies]
+insta = "1.38"

--- a/tests/snapshots/main__with_excluded_member@config__Cargo.toml.snap
+++ b/tests/snapshots/main__with_excluded_member@config__Cargo.toml.snap
@@ -1,0 +1,25 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-config"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without config files being in place, etc.
+doctest = false
+
+[dependencies]
+anyhow = { workspace = true }
+dotenvy = { workspace = true }
+figment = { workspace = true, features = ["toml", "env"] }
+serde = { workspace = true, features = ["derive"] } 
+tracing = { workspace = true }
+
+[dev-dependencies]
+figment = { workspace = true, features = ["toml", "env", "test"] }
+googletest = { workspace = true }

--- a/tests/snapshots/main__with_excluded_member@db__Cargo.toml.snap
+++ b/tests/snapshots/main__with_excluded_member@db__Cargo.toml.snap
@@ -1,0 +1,31 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-db"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without a running database, etc.
+doctest = false
+
+[features]
+test-helpers = ["dep:fake", "dep:rand", "dep:regex"]
+openapi = ["dep:utoipa"]
+
+[dependencies]
+anyhow = { workspace = true }
+fake = { workspace = true, features = ["derive"], optional = true }
+cargo-autoinherit-test-config = { workspace = true }
+rand = { workspace = true, optional = true }
+regex = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "migrate", "chrono"] }
+thiserror = { workspace = true }
+utoipa = { workspace = true, features = ["uuid"], optional = true }
+uuid = { workspace = true, features = ["serde"] }
+validator = { workspace = true, features = ["derive"] }

--- a/tests/snapshots/main__with_excluded_member@macros__Cargo.toml.snap
+++ b/tests/snapshots/main__with_excluded_member@macros__Cargo.toml.snap
@@ -1,0 +1,19 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-macros"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+proc-macro = true
+# examples in docs don't run without a running database, etc.
+doctest = false
+
+[dependencies]
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }

--- a/tests/snapshots/main__with_excluded_member@web__Cargo.toml.snap
+++ b/tests/snapshots/main__with_excluded_member@web__Cargo.toml.snap
@@ -1,0 +1,45 @@
+---
+source: tests/main.rs
+expression: input
+snapshot_kind: text
+---
+[package]
+name = "cargo-autoinherit-test-web"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+# examples in docs don't run without a running database, etc.
+doctest = false
+
+[features]
+test-helpers = ["dep:serde_json", "dep:tower", "dep:hyper"]
+
+[dependencies]
+anyhow = "1.0"
+axum = { version = "0.7", features = ["macros"] }
+cargo-autoinherit-test-config = { path = "../config" }
+cargo-autoinherit-test-db = { path = "../db", features = ["openapi"] }
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.34", features = ["full"] }
+tower-http = { version = "0.6", features = ["full"] }
+tracing = "0.1"
+tracing-panic = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry", "fmt"] }
+uuid = { version = "1.6", features = ["serde"] }
+serde_json = { version = "1.0", optional = true }
+thiserror = "1.0"
+tower = { version = "0.5", features = ["util"], optional = true }
+hyper = { version = "1.0", features = ["full"], optional = true }
+cargo-autoinherit-test-macros = { path = "../macros" }
+validator = { version = "0.18.1", features = ["derive"] }
+utoipa = { version = "5.1.2", features = ["axum_extras", "uuid"] }
+utoipa-axum = {version = "0.1.2" }
+utoipa-swagger-ui = { version = "8.0.3", features = ["axum", "reqwest"] }
+
+[dev-dependencies]
+fake = "2.9"
+googletest = "0.12"
+cargo-autoinherit-test-db = { path = "../db", features = ["test-helpers"] }
+cargo-autoinherit-test-web = { path = ".", features = ["test-helpers"] }


### PR DESCRIPTION
Adds snapshot tests to assert the correctness of the updates to the manifest files.

I'm not sure if cloning an external repo (https://github.com/hdoordt/cargo-autoinherit-test for now) is optimal, but I figured both checking in a test project or adding a submodule were not ideal.

TODO:
- [ ] In case we do want to clone an external repo, use one that lives in the mainmatter org