### PR TITLE
feat: sort workspace dependencies by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ pub struct AutoInheritConf {
     /// Package name(s) of workspace member(s) to exclude.
     #[arg(short, long)]
     exclude_members: Vec<String>,
+    /// Disables sorting the dependencies in the workspace.dependencies table.
+    #[arg(long)]
+    pub no_sort_workspace_deps: bool,
 }
 
 #[derive(Debug, Default)]
@@ -239,6 +242,10 @@ pub fn auto_inherit(conf: AutoInheritConf) -> Result<(), anyhow::Error> {
         }
     }
     if was_modified {
+        if !conf.no_sort_workspace_deps {
+            workspace_deps.sort_values();
+        }
+
         fs_err::write(
             workspace_root.join("Cargo.toml").as_std_path(),
             workspace_toml.to_string(),


### PR DESCRIPTION
I like my dependencies sorted, and `cargo add` and friends usually try to keep them that way by default. This changes the default behaviour of `cargo-autoinherit` to sort `[workspace.dependencies]` by default, and adds a `--no-sort-workspace-deps` flag to handle anyone who doesn't want that behaviour.