### PR TITLE
feat: improve error message when path does not exist

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,9 @@ fn rewrite_dep_paths_as_absolute<'a, P: AsRef<std::path::Path>>(
             detail.path = detail.path.as_mut().map(|path| {
                 parent
                     .as_ref()
-                    .join(path)
+                    .join(&path)
                     .canonicalize()
-                    .unwrap()
+                    .unwrap_or_else(|_| panic!("A dependency refers to the path {}, which does not exist.", path.display()))
                     .to_str()
                     .expect("Canonicalized absolute path contained non-UTF-8 segments.")
                     .to_string()


### PR DESCRIPTION
If you have a Cargo.toml like

```
foo = { path = "bad/path" }
```
you will presently get a nameless panic. This adds some error information to the panic, hopefully helping other people in the future.